### PR TITLE
Feat: 모달 컴포넌트

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import { IProps } from './types';
+import useClickAway from '@/hooks/useClickAway';
+
+const Modal = ({ children, visible, onClose, ...rest }: IProps) => {
+  const ref = useClickAway(onClose);
+
+  return createPortal(
+    <div
+      style={{ ...rest.style, display: visible ? 'block' : 'none' }}
+      className="fixed left-0 top-0 z-50 h-screen w-screen bg-black/30"
+    >
+      <div
+        ref={ref}
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default Modal;

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,20 +1,23 @@
 'use client';
 
 import { createPortal } from 'react-dom';
-import { IProps } from './types';
+
 import useClickAway from '@/hooks/useClickAway';
+
+import { IProps } from './types';
 
 const Modal = ({ children, visible, onClose, ...rest }: IProps) => {
   const ref = useClickAway(onClose);
 
   return createPortal(
     <div
-      style={{ ...rest.style, display: visible ? 'block' : 'none' }}
+      style={{ display: visible ? 'block' : 'none' }}
       className="fixed left-0 top-0 z-50 h-screen w-screen bg-black/30"
     >
       <div
         ref={ref}
         className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        style={{ ...rest.style }}
       >
         {children}
       </div>

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,0 +1,7 @@
+import { HTMLAttributes, ReactNode } from 'react';
+
+export interface IProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  visible: boolean;
+  onClose: () => void;
+}


### PR DESCRIPTION
## ✨ Jira 티켓 링크
https://devcourse-i6.atlassian.net/jira/software/projects/HTV/boards/1?selectedIssue=HTV-154

## 📝 핵심 구현 사항
모달 컴포넌트 구현했습니다.

## ✅ 그 외 구현 사항

## 💬 PR 포인트
- ref와 document.body는 ssr에서 참조할 수 없어서 클라이언트에서만 실행되도록 했습니다.
모달 컴포넌트 사용하실 때 import를 
```jsx
import dynamic from 'next/dynamic';
const Modal = dynamic(() => import('@/components/modal'), { ssr: false });
```
이렇게 받아 사용하시면 됩니다.

- useClickAway 훅은 아직 머지가 안되서 예측샷으로 했습니다. 테스트도  했는데 잘 작동합니다.

## 📢 질문사항
useEffect 내에서 처리해볼려 했는데 가독성도 안좋아지고 너무 복잡해져서 동적 import를 사용하도록 구현했는데 더 좋은 방법이 있을까요
