### PR TITLE
Design: 면접 전 페이지 이용약관 화면 구현

### DIFF
--- a/src/container/presetting/components/buttonSection/index.tsx
+++ b/src/container/presetting/components/buttonSection/index.tsx
@@ -4,7 +4,8 @@ import { ButtonType } from '@/components/button/types';
 import useStepStore from '../../stores/useStepStore';
 
 const PreSettingButtonSection = () => {
-  const { currentStep, increaseStep, decreaseStep } = useStepStore();
+  const { currentStep, increaseStep, decreaseStep, isNextButtonOn } =
+    useStepStore();
 
   const handlePrevButton = () => {
     if (currentStep > 1) {
@@ -26,16 +27,17 @@ const PreSettingButtonSection = () => {
     <div className="absolute bottom-0 flex gap-[1rem]">
       <Button
         styleType={ButtonType.Type3}
-        className="bottom-[2.86rem] text-medium"
+        className="bottom-[2.86rem]"
         onClick={handlePrevButton}
         style={{ height: '4rem', width: '9rem' }}
       >
         이전
       </Button>
       <Button
-        className="bottom-[2.86rem] text-medium"
+        className="bottom-[2.86rem]"
         onClick={handleNextButton}
         style={{ height: '4rem', width: '9rem' }}
+        disabled={!isNextButtonOn}
       >
         {currentStep === 4 ? '시작' : '다음'}
       </Button>

--- a/src/container/presetting/components/sceneSection/components/interviewTypeScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewTypeScene/index.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+
+import Select from '@/components/select';
+import useStepStore from '@/container/presetting/stores/useStepStore';
+
+const InterviewTypeScene = () => {
+  const { setNextButton } = useStepStore();
+
+  useEffect(() => {
+    setNextButton(true);
+  }, [setNextButton]);
+
+  return (
+    <Select
+      value=""
+      options={[]}
+    />
+  );
+};
+
+export default InterviewTypeScene;

--- a/src/container/presetting/components/sceneSection/components/questionScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/questionScene/index.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import Input from '@/components/input';
+import useStepStore from '@/container/presetting/stores/useStepStore';
+
+const QuestionScene = () => {
+  const { setNextButton } = useStepStore();
+
+  useEffect(() => {
+    setNextButton(true);
+  }, [setNextButton]);
+  return <Input>질문을 선택하세요</Input>;
+};
+
+export default QuestionScene;

--- a/src/container/presetting/components/sceneSection/components/settingCameraScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/settingCameraScene/index.tsx
@@ -1,0 +1,24 @@
+import { MirrorView } from '@/components/camera';
+import { SpinnerIcon } from '@/components/icon';
+
+import useSettingCameraScene from './useSettingCameraScene';
+
+const SettingCameraScene = () => {
+  const { previewStream, isLoading } = useSettingCameraScene();
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full justify-center">
+        <SpinnerIcon />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <MirrorView stream={previewStream} />
+    </>
+  );
+};
+
+export default SettingCameraScene;

--- a/src/container/presetting/components/sceneSection/components/settingCameraScene/useSettingCameraScene.tsx
+++ b/src/container/presetting/components/sceneSection/components/settingCameraScene/useSettingCameraScene.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+import { useCamera } from '@/components/camera';
+
+const useSettingCameraScene = () => {
+  const {
+    status,
+    isLoading,
+    isRecording,
+    startRecording,
+    previewStream,
+    error,
+    pauseRecording,
+  } = useCamera();
+
+  useEffect(() => {
+    startRecording();
+  }, [startRecording]);
+
+  useEffect(() => {
+    if (isRecording) {
+      pauseRecording();
+    }
+  }, [isRecording, pauseRecording]);
+
+  return {
+    previewStream,
+    isLoading,
+    status,
+  };
+};
+
+export default useSettingCameraScene;

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
@@ -22,11 +22,11 @@ const TermsAgreeSection = () => {
   return (
     <label
       htmlFor="agree"
-      className="flex w-full items-center justify-center gap-[1rem]"
+      className="flex w-full items-center justify-center gap-[1rem] font-semibold"
     >
       <input
         type="checkbox"
-        className="h-[1.5rem] w-[1.5rem] font-semibold"
+        className="h-[1.5rem] w-[1.5rem]"
         id="agree"
         onChange={handleCheckChange}
       />

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
@@ -1,24 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import useStepStore from '@/container/presetting/stores/useStepStore';
 
 import { TERMS_AGREE_TEXT } from '../../constants';
 
 const TermsAgreeSection = () => {
-  const [isChecked, setIsChecked] = useState(false);
   const { setNextButton } = useStepStore();
+
+  useEffect(() => {
+    setNextButton(false);
+  }, []);
 
   const handleCheckChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target) {
       return;
     }
     const { checked } = e.target;
-    setIsChecked(checked);
+    setNextButton(checked);
   };
-
-  useEffect(() => {
-    setNextButton(isChecked);
-  }, [isChecked, setNextButton]);
 
   return (
     <label

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsAgreeSection/index.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+import useStepStore from '@/container/presetting/stores/useStepStore';
+
+import { TERMS_AGREE_TEXT } from '../../constants';
+
+const TermsAgreeSection = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const { setNextButton } = useStepStore();
+
+  const handleCheckChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target) {
+      return;
+    }
+    const { checked } = e.target;
+    setIsChecked(checked);
+  };
+
+  useEffect(() => {
+    setNextButton(isChecked);
+  }, [isChecked, setNextButton]);
+
+  return (
+    <label
+      htmlFor="agree"
+      className="flex w-full items-center justify-center gap-[1rem]"
+    >
+      <input
+        type="checkbox"
+        className="h-[1.5rem] w-[1.5rem] font-semibold"
+        id="agree"
+        onChange={handleCheckChange}
+      />
+      {TERMS_AGREE_TEXT}
+    </label>
+  );
+};
+
+export default TermsAgreeSection;

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsDescriptionSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsDescriptionSection/index.tsx
@@ -1,0 +1,44 @@
+import {
+  TERMS_DENY_TEXT,
+  TERMS_DURATION_TEXT,
+  TERMS_DURATION_TITLE,
+  TERMS_GOAL_TEXT,
+  TERMS_GOAL_TITLE,
+  TERMS_TARGET_TEXT,
+  TERMS_TARGET_TITLE,
+  TERMS_TITLE,
+} from '../../constants';
+
+const TermsDescriptionSection = () => {
+  return (
+    <>
+      <p className="mb-[1rem] font-semibold">{TERMS_TITLE}</p>
+      <div className="mb-[1rem] flex">
+        <div className="w-[23rem] border border-r-0">
+          <div className="bg-background-20 py-[1rem] pl-[1rem]">
+            {TERMS_GOAL_TITLE}
+          </div>
+          <div className="h-[5rem] py-[1rem] pl-[1rem]">{TERMS_GOAL_TEXT}</div>
+        </div>
+        <div className="w-[32rem] border border-r-0">
+          <div className="bg-background-20 py-[1rem] pl-[1rem]">
+            {TERMS_TARGET_TITLE}
+          </div>
+          <div className="py-[1rem] pl-[1rem]">{TERMS_TARGET_TEXT}</div>
+        </div>
+        <div className="w-[20rem] border">
+          <div className="bg-background-20 py-[1rem] pl-[1rem]">
+            {TERMS_DURATION_TITLE}
+          </div>
+          <ul className="py-[1rem] pl-[1rem]">
+            <li>{TERMS_DURATION_TEXT[0]}</li>
+            <li>{TERMS_DURATION_TEXT[1]}</li>
+          </ul>
+        </div>
+      </div>
+      <div className="mb-[5rem]">{TERMS_DENY_TEXT}</div>
+    </>
+  );
+};
+
+export default TermsDescriptionSection;

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsHeaderSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsHeaderSection/index.tsx
@@ -1,0 +1,17 @@
+import { TERMS_DESCRIPTION, TERMS_HEADER } from '../../constants';
+
+const TermsHeaderSection = () => {
+  return (
+    <>
+      <h1 className="mb-[1rem] flex w-full justify-center text-extraLarge font-bold">
+        {TERMS_HEADER}
+      </h1>
+      <div className="mb-[5rem] w-full flex-col">
+        <p className="flex justify-center ">{TERMS_DESCRIPTION[0]}</p>
+        <p className="flex justify-center">{TERMS_DESCRIPTION[1]}</p>
+      </div>
+    </>
+  );
+};
+
+export default TermsHeaderSection;

--- a/src/container/presetting/components/sceneSection/components/termsScene/constants/index.ts
+++ b/src/container/presetting/components/sceneSection/components/termsScene/constants/index.ts
@@ -1,0 +1,18 @@
+export const TERMS_HEADER = '화상 면접 연습 약관 동의';
+export const TERMS_DESCRIPTION = [
+  '혼터뷰는 오로지 사용자 본인의 연습 영상 확인을 위해 녹화 영상을 저장합니다',
+];
+export const TERMS_TITLE = '개인정보 수집 및 이용 동의(필수)';
+export const TERMS_GOAL_TITLE = '수집목적';
+export const TERMS_GOAL_TEXT = '사용자 본인의 면접 연습 결과 확인';
+export const TERMS_TARGET_TITLE = '수집항목';
+export const TERMS_TARGET_TEXT =
+  '웹캠 또는 휴대전화 카메라로 촬영된 사용자 영상';
+export const TERMS_DURATION_TITLE = '보유 및 이용 기간';
+export const TERMS_DURATION_TEXT = [
+  '- 답변 미저장 시 즉시 파기',
+  '- 저장 시 연습 30일 후 파기',
+];
+export const TERMS_DENY_TEXT =
+  '개인정보 수집과 이용을 거부할 권리가 있으나, 미동의 시 면접 화상 연습의 이용이 불가한 점을 알려드립니다';
+export const TERMS_AGREE_TEXT = '동의합니다';

--- a/src/container/presetting/components/sceneSection/components/termsScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import TermsAgreeSection from './components/termsAgreeSection';
+import TermsDescriptionSection from './components/termsDescriptionSection';
+import TermsHeaderSection from './components/termsHeaderSection';
+
+const TermsScene = () => {
+  return (
+    <div className="flex h-full flex-col justify-center text-medium">
+      <TermsHeaderSection />
+      <TermsDescriptionSection />
+      <TermsAgreeSection />
+    </div>
+  );
+};
+
+export default TermsScene;

--- a/src/container/presetting/components/sceneSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/index.tsx
@@ -1,0 +1,19 @@
+import useStepStore from '../../stores/useStepStore';
+import InterviewTypeScene from './components/interviewTypeScene';
+import QuestionScene from './components/questionScene';
+import SettingCameraScene from './components/settingCameraScene';
+import TermsScene from './components/termsScene';
+
+const PreSettingSceneSection = () => {
+  const { currentStep } = useStepStore();
+  return (
+    <div className="h-[50rem]">
+      {currentStep === 1 && <QuestionScene />}
+      {currentStep === 2 && <InterviewTypeScene />}
+      {currentStep === 3 && <TermsScene />}
+      {currentStep === 4 && <SettingCameraScene />}
+    </div>
+  );
+};
+
+export default PreSettingSceneSection;

--- a/src/container/presetting/components/sceneSection/type.ts
+++ b/src/container/presetting/components/sceneSection/type.ts
@@ -1,3 +1,0 @@
-export interface PresettingSceneProps {
-  page: number;
-}

--- a/src/container/presetting/components/sceneSection/type.ts
+++ b/src/container/presetting/components/sceneSection/type.ts
@@ -1,0 +1,3 @@
+export interface PresettingSceneProps {
+  page: number;
+}

--- a/src/container/presetting/components/stepSection/components/stepCircle/index.tsx
+++ b/src/container/presetting/components/stepSection/components/stepCircle/index.tsx
@@ -13,11 +13,11 @@ const StepCircle = ({
   return (
     <div className="flex flex-col items-center justify-center">
       <div
-        className={`border-box inline-flex h-[4rem] w-[4rem] items-center justify-center rounded-full text-medium ${bgColor} ${textColor}`}
+        className={`border-box inline-flex h-[4rem] w-[4rem] items-center justify-center rounded-full ${bgColor} ${textColor}`}
       >
         {number}
       </div>
-      <p className={`${titleColor} absolute bottom-0 text-medium`}>{title}</p>
+      <p className={`${titleColor} absolute bottom-0`}>{title}</p>
     </div>
   );
 };

--- a/src/container/presetting/index.tsx
+++ b/src/container/presetting/index.tsx
@@ -3,13 +3,15 @@
 import Divider from '@/components/divider';
 
 import PreSettingButtonSection from './components/buttonSection';
+import PreSettingSceneSection from './components/sceneSection';
 import StepSection from './components/stepSection';
 
 const PreSetting = () => {
   return (
-    <div className="flex h-[70rem] w-full max-w-[80rem] flex-col items-center rounded-3xl bg-text-20 bg-opacity-20 shadow-xl backdrop-blur-xl">
+    <div className="flex h-[70rem] w-full max-w-[80rem] flex-col items-center rounded-3xl bg-text-20 bg-opacity-20 text-medium shadow-xl backdrop-blur-xl">
       <StepSection />
       <Divider className="mt-[2.6rem] w-[75rem]" />
+      <PreSettingSceneSection />
       <PreSettingButtonSection />
     </div>
   );

--- a/src/container/presetting/stores/type.ts
+++ b/src/container/presetting/stores/type.ts
@@ -1,5 +1,7 @@
 export interface StepState {
   currentStep: number;
+  isNextButtonOn: boolean;
   increaseStep: () => void;
   decreaseStep: () => void;
+  setNextButton: (checked: boolean) => void;
 }

--- a/src/container/presetting/stores/useStepStore.ts
+++ b/src/container/presetting/stores/useStepStore.ts
@@ -4,10 +4,12 @@ import { StepState } from './type';
 
 const useStepStore = create<StepState>((set) => ({
   currentStep: 1,
+  isNextButtonOn: false,
   increaseStep: () =>
     set(({ currentStep }) => ({ currentStep: currentStep + 1 })),
   decreaseStep: () =>
     set(({ currentStep }) => ({ currentStep: currentStep - 1 })),
+  setNextButton: (checked) => set(() => ({ isNextButtonOn: checked })),
 }));
 
 export default useStepStore;


### PR DESCRIPTION
## ✨ Jira 티켓 링크
<!-- 주소 뒤에 티켓번호를 적어주세요 -->
https://devcourse-i6.atlassian.net/browse/htv-62

## 📝 핵심 구현 사항
<!-- 핵심 기능에 대한 설명 -->
- 면접 전 페이지에서 이용약관 scene을 구현했습니다
- 다음 버튼의 disable 처리를 스토어 상태로 판단합니다
<img width="1466" alt="image" src="https://github.com/DevCourse-I6/Team-I6-Honterview-FE/assets/68155263/f993d2ca-85f2-4375-b5ec-3d0f741b8bcc">

## ✅ 그 외 구현 사항
<!-- 핵심 외 구현 설명 -->
- 면접 전 페이지에서 쓰이는 나머지 세단계 화면의 컴포넌트를 생성했습니다(그래서 이 화면들은 네이밍 정도만 봐주시면 될 것 같아요)
- 폰트 크기를 면접 전 페이지의 최상단에 한번만 선언하도록 변경했습니다

## 💬 PR 포인트
<!-- PR에서 중점적으로 봐야할 부분 (ex.PR 좀 봐주세요~) -->
- 체크박스는 우선 기본으로 구현했습니다!

## 📢 질문사항
<!-- 질문 & 애로사항 공유 (ex. 어떻게 생각하시나요?) -->