### PR TITLE
Fix: 면접 전 페이지 버그 수정(타이머, 화상 url, 스피너)

### DIFF
--- a/src/components/camera/components/MirrorView.tsx
+++ b/src/components/camera/components/MirrorView.tsx
@@ -22,16 +22,16 @@ const MirrorView = ({
     }
   }, [stream]);
 
+  if (isLoading) {
+    return <Loading />;
+  }
+
   if (error) {
     return <CameraErrorView error={error} />;
   }
 
   if (!stream) {
     return null;
-  }
-
-  if (isLoading) {
-    return <Loading />;
   }
 
   return (

--- a/src/container/presetting/components/buttonSection/index.tsx
+++ b/src/container/presetting/components/buttonSection/index.tsx
@@ -25,7 +25,7 @@ const PreSettingButtonSection = () => {
       increaseStep();
     } else {
       router.push(
-        interviewType === 'camera' ? '/interview/camera' : 'interview/chatting',
+        interviewType === 'camera' ? '/interview/video' : 'interview/chatting',
       );
     }
   };

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
@@ -8,7 +8,9 @@ import { minuteData, secondData } from './constants';
 const TimerSection = () => {
   const { setTimeMinute, setTimeSecond, interviewType, answerTime } =
     usePresettingDataStore();
-  const [isSecondDisabled, setIsSecondDisabled] = useState(false);
+  const [isSecondDisabled, setIsSecondDisabled] = useState(
+    answerTime.minute === minuteData[minuteData.length - 1],
+  );
 
   if (interviewType === 'chatting') {
     return;


### PR DESCRIPTION
## ✨ Jira 티켓 링크
<!-- 주소 뒤에 티켓번호를 적어주세요 -->
https://devcourse-i6.atlassian.net/browse/htv-216

## 📝 핵심 구현 사항
<!-- 핵심 기능에 대한 설명 -->
- 화상 면접 페이지 이동 url을 수정했습니다
- 2단계 페이지를 벗어났다가 돌아왔을 때, 타이머가 10분 초과 세팅이 가능해지는 버그를 수정했습니다
- 4단계에서 카메라 로딩 스피너가 보이지 않는 이슈를 수정했습니다

## ✅ 그 외 구현 사항
<!-- 핵심 외 구현 설명 -->


## 💬 PR 포인트
<!-- PR에서 중점적으로 봐야할 부분 (ex.PR 좀 봐주세요~) -->


## 📢 질문사항
<!-- 질문 & 애로사항 공유 (ex. 어떻게 생각하시나요?) -->
