### PR TITLE
Feat: OAuth2 기능 개발

### DIFF
--- a/src/app/api/interview/[id]/route.ts
+++ b/src/app/api/interview/[id]/route.ts
@@ -10,7 +10,9 @@ export const GET = (
     return new Response(null, { status: 404 });
   }
 
-  const result = interviews.filter(({ interviewId }) => interviewId === id);
+  const result = interviews.filter(
+    ({ interviewId }) => String(interviewId) === id,
+  );
 
   return Response.json({ message: 'ok', data: result[0] }, { status: 200 });
 };

--- a/src/container/authLogin/components/loginButtonItem/index.tsx
+++ b/src/container/authLogin/components/loginButtonItem/index.tsx
@@ -1,9 +1,11 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import { twMerge } from 'tailwind-merge';
 
 import { IProps } from './types';
 
 const LoginButtonItem = ({
-  // eslint-disable-next-line unused-imports/no-unused-vars
   provider,
   name,
   icon,
@@ -11,14 +13,21 @@ const LoginButtonItem = ({
   textColor,
   ...rest
 }: IProps) => {
+  const router = useRouter();
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
   const buttonStyle = twMerge(
     `border-#e1e2e4 flex h-[5rem] w-full items-center justify-center gap-4 rounded-2xl border border-solid px-4 ${backgroundColor} ${textColor} ${rest.className}`,
   );
 
+  const handleRedirectToSocialLogin = () => {
+    router.push(`${API_BASE_URL}oauth2/authorization/${provider}`);
+  };
+
   return (
     <li className="flex w-full justify-center">
       <button
-        type="submit"
+        type="button"
+        onClick={handleRedirectToSocialLogin}
         className={`${buttonStyle}`}
       >
         {icon}

--- a/src/container/authLogin/constants/loginButtons.tsx
+++ b/src/container/authLogin/constants/loginButtons.tsx
@@ -1,9 +1,4 @@
-import {
-  GithubIcon,
-  GoogleIcon,
-  KakaoIcon,
-  NaverIcon,
-} from '@/components/icon';
+import { GithubIcon, GoogleIcon, KakaoIcon } from '@/components/icon';
 
 export const LOGIN_BUTTONS = [
   {
@@ -20,13 +15,13 @@ export const LOGIN_BUTTONS = [
     backgroundColor: 'bg-[#ffffff]',
     textColor: 'text-text-100',
   },
-  {
-    provider: 'naver',
-    name: '네이버 로그인',
-    icon: <NaverIcon />,
-    backgroundColor: 'bg-[#03C75A]',
-    textColor: 'text-text-20',
-  },
+  // {
+  //   provider: 'naver',
+  //   name: '네이버 로그인',
+  //   icon: <NaverIcon />,
+  //   backgroundColor: 'bg-[#03C75A]',
+  //   textColor: 'text-text-20',
+  // },
   {
     provider: 'kakao',
     name: '카카오 로그인',

--- a/src/container/interviewVideo/components/answerTimeProgressGroup/index.tsx
+++ b/src/container/interviewVideo/components/answerTimeProgressGroup/index.tsx
@@ -10,7 +10,7 @@ const AnswerTimeProgressGroup = () => {
   const { questionCount, questions } = useInterview();
   const progressArray = Array.from(
     { length: questionCount },
-    (_, index) => questions[index] && questions[index].progressingTime,
+    (_, index) => questions[index] && questions[index].processingTime,
   );
 
   return (

--- a/src/container/interviewVideo/components/initializeInterview/index.tsx
+++ b/src/container/interviewVideo/components/initializeInterview/index.tsx
@@ -1,46 +1,42 @@
 'use client';
 
-import { useEffect } from 'react';
-
-import { useInterview, useQuestionContent } from '@/stores/interviewProgress';
-
 import { IProps } from './types';
 
 const InitializeInterview = ({
-  interviewId,
-  interviewData,
+  // interviewId,
+  // interviewData,
   children,
 }: IProps) => {
-  const { questionContent, questionCount, timer, questions, categories } =
-    interviewData;
-  const { id, setInterview } = useInterview();
-  const { setQuestionContent } = useQuestionContent();
+  // const { questionContent, questionCount, timer, questions, categories } =
+  //   interviewData;
+  // const { id, setInterview } = useInterview();
+  // const { setQuestionContent } = useQuestionContent();
 
-  useEffect(() => {
-    if (!id) {
-      setInterview({
-        id: interviewId,
-        questionCount,
-        limitTimer: timer,
-        questions,
-        categories,
-      });
-    }
-  }, [
-    id,
-    interviewId,
-    setInterview,
-    questionCount,
-    timer,
-    questions,
-    categories,
-  ]);
+  // useEffect(() => {
+  //   if (!id) {
+  //     setInterview({
+  //       id: interviewId,
+  //       questionCount,
+  //       limitTimer: timer,
+  //       questions,
+  //       categories,
+  //     });
+  //   }
+  // }, [
+  //   id,
+  //   interviewId,
+  //   setInterview,
+  //   questionCount,
+  //   timer,
+  //   questions,
+  //   categories,
+  // ]);
 
-  useEffect(() => {
-    if (questions.length === 0) {
-      setQuestionContent(questionContent);
-    }
-  }, [questions.length, setQuestionContent, questionContent]);
+  // useEffect(() => {
+  //   if (questions.length === 0) {
+  //     setQuestionContent(questionContent);
+  //   }
+  // }, [questions.length, setQuestionContent, questionContent]);
 
   return <>{children}</>;
 };

--- a/src/libs/actions/auth.ts
+++ b/src/libs/actions/auth.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { apiServer } from '@/utils/apiServer';
+
+export const reissueAccessToken = async <T>(callback: () => Promise<T>) => {
+  const response = await apiServer.post('api/v1/auth/reissue');
+
+  if (response.status === 401) {
+    return redirect('/auth/login');
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return callback();
+};

--- a/src/libs/services/interview.ts
+++ b/src/libs/services/interview.ts
@@ -1,23 +1,22 @@
-import { apiClient } from '@/utils/apiClient';
+import { IResponseInterview } from '@/types/Response/interview';
+import { apiServer } from '@/utils/apiServer';
 
-export const getInterviewInfo = async (interviewId: string) => {
-  try {
-    const response = await apiClient.get(`api/interview/${interviewId}`, {
-      cache: 'no-store',
-    });
+import { reissueAccessToken } from '../actions/auth';
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
+export const getInterviewInfo = async (
+  interviewId: string,
+): Promise<IResponseInterview> => {
+  const response = await apiServer.get(`api/v1/interviews/${interviewId}`, {
+    cache: 'no-store',
+  });
 
-    const data = await response.json();
-
-    return data;
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(error.message);
-    }
-
-    throw new Error(String(error));
+  if (response.status === 401) {
+    return reissueAccessToken(() => getInterviewInfo(interviewId));
   }
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { type NextRequest } from 'next/server';
+
+export const middleware = async (request: NextRequest) => {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/auth/login')) {
+    // 서버에 인증 확인 후 redirect 처리
+    // return NextResponse.redirect(new URL('/', request.url));
+  }
+};
+
+export const config = {
+  matcher: ['/auth/login'],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const middleware = async (request: NextRequest) => {
+  const { pathname } = request.nextUrl;
+  const cookiesList = cookies();
+  const hasRefreshToken = cookiesList.has('refreshToken');
+
+  if (pathname.startsWith('/auth/login') && hasRefreshToken) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+};
+
+export const config = {
+  matcher: ['/auth/login'],
+};

--- a/src/mocks/fixtures/interview.ts
+++ b/src/mocks/fixtures/interview.ts
@@ -1,6 +1,4 @@
-import { IInterview } from '@/types/interview';
-
-export const interviews: IInterview[] = [
+export const interviews = [
   {
     interviewId: '123',
     questionContent: '렌더링 과정을 설명해주세요',

--- a/src/types/Response/interview.ts
+++ b/src/types/Response/interview.ts
@@ -1,0 +1,6 @@
+import { IInterview } from '../interview';
+
+export interface IResponseInterview {
+  message: string;
+  data: IInterview;
+}

--- a/src/types/interview.ts
+++ b/src/types/interview.ts
@@ -1,10 +1,10 @@
 import { IQuestion } from './question';
 
 export interface IInterview {
-  interviewId: string;
-  questionContent: string;
-  questionCount: number;
+  interviewId: number;
   timer: number;
-  questions: IQuestion[];
-  categories: string[];
+  answerType: string;
+  questionCount: number;
+  questionsAndAnswers: IQuestion[];
+  categoryNames: string[];
 }

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -1,6 +1,8 @@
 export interface IQuestion {
   questionId: number;
-  content: string;
-  progressingTime: number;
+  questionContent: string;
+  answerId: number;
   answerContent: string;
+  processingTime: number;
+  videoId: number;
 }

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -1,52 +1,100 @@
+import { cookies } from 'next/headers';
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 const get = (url: string, options: RequestInit = {}) => {
+  let accessToken = null;
+
+  if (typeof window === 'undefined') {
+    const cookieStore = cookies();
+
+    accessToken = cookieStore.get('accessToken');
+  }
+
   return fetch(`${API_BASE_URL}${url}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
     method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 const post = (url: string, options: RequestInit = {}) => {
+  let accessToken = null;
+
+  if (typeof window === 'undefined') {
+    const cookieStore = cookies();
+    accessToken = cookieStore.get('accessToken');
+  }
+
   return fetch(`${API_BASE_URL}${url}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 const put = (url: string, options: RequestInit = {}) => {
+  let accessToken = null;
+
+  if (typeof window === 'undefined') {
+    const cookieStore = cookies();
+    accessToken = cookieStore.get('accessToken');
+  }
+
   return fetch(`${API_BASE_URL}${url}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
     method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 const del = (url: string, options: RequestInit = {}) => {
+  let accessToken = null;
+
+  if (typeof window === 'undefined') {
+    const cookieStore = cookies();
+    accessToken = cookieStore.get('accessToken');
+  }
+
   return fetch(`${API_BASE_URL}${url}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
     method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 const patch = (url: string, options: RequestInit = {}) => {
+  let accessToken = null;
+
+  if (typeof window === 'undefined') {
+    const cookieStore = cookies();
+    accessToken = cookieStore.get('accessToken');
+  }
+
   return fetch(`${API_BASE_URL}${url}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
     method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable unused-imports/no-unused-vars */
-import { cookies } from 'next/headers';
-
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 const getAccessToken = () => {
@@ -14,14 +10,6 @@ const getAccessToken = () => {
 };
 
 const get = (url: string, options: RequestInit = {}) => {
-  let accessToken = null;
-
-  if (typeof window === 'undefined') {
-    const cookieStore = cookies();
-
-    accessToken = cookieStore.get('accessToken');
-  }
-
   return fetch(`${API_BASE_URL}${url}`, {
     ...options,
     method: 'GET',
@@ -35,13 +23,6 @@ const get = (url: string, options: RequestInit = {}) => {
 };
 
 const post = (url: string, options: RequestInit = {}) => {
-  let accessToken = null;
-
-  if (typeof window === 'undefined') {
-    const cookieStore = cookies();
-    accessToken = cookieStore.get('accessToken');
-  }
-
   return fetch(`${API_BASE_URL}${url}`, {
     ...options,
     method: 'POST',
@@ -55,13 +36,6 @@ const post = (url: string, options: RequestInit = {}) => {
 };
 
 const put = (url: string, options: RequestInit = {}) => {
-  let accessToken = null;
-
-  if (typeof window === 'undefined') {
-    const cookieStore = cookies();
-    accessToken = cookieStore.get('accessToken');
-  }
-
   return fetch(`${API_BASE_URL}${url}`, {
     ...options,
     method: 'PUT',
@@ -75,13 +49,6 @@ const put = (url: string, options: RequestInit = {}) => {
 };
 
 const del = (url: string, options: RequestInit = {}) => {
-  let accessToken = null;
-
-  if (typeof window === 'undefined') {
-    const cookieStore = cookies();
-    accessToken = cookieStore.get('accessToken');
-  }
-
   return fetch(`${API_BASE_URL}${url}`, {
     ...options,
     method: 'DELETE',
@@ -95,13 +62,6 @@ const del = (url: string, options: RequestInit = {}) => {
 };
 
 const patch = (url: string, options: RequestInit = {}) => {
-  let accessToken = null;
-
-  if (typeof window === 'undefined') {
-    const cookieStore = cookies();
-    accessToken = cookieStore.get('accessToken');
-  }
-
   return fetch(`${API_BASE_URL}${url}`, {
     ...options,
     method: 'PATCH',

--- a/src/utils/apiServer.ts
+++ b/src/utils/apiServer.ts
@@ -1,12 +1,9 @@
+import { cookies } from 'next/headers';
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 const getAccessToken = () => {
-  const accessToken = document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('accessToken='))
-    ?.split('=')[1];
-
-  return accessToken || '';
+  return cookies().get('accessToken') || '';
 };
 
 const get = (url: string, options: RequestInit = {}) => {
@@ -74,4 +71,4 @@ const patch = (url: string, options: RequestInit = {}) => {
   });
 };
 
-export const apiClient = { get, post, put, delete: del, patch };
+export const apiServer = { get, post, put, delete: del, patch };


### PR DESCRIPTION
## ✨ Jira 티켓 링크
https://devcourse-i6.atlassian.net/browse/HTV-127

## 📝 핵심 구현 사항
- 로그인 버튼 클릭 시 인가 페이지 이동 기능 개발
- fetch 함수에 accessToken을 자동으로 header에 저장하도록 수정
- 미들웨어 설정하여 페이지 진입 가로채도록 구현
- 재 인증 받는 api 함수 구현 

## ✅ 그 외 구현 사항

## 💬 PR 포인트
- 인가 페이지 이동은 아직 카카오만 구현이 되어있다고 합니다.

- 토큰을 쿠키에서 가져와야하는데 서버 사이드, 클라이언트 사이드에서 방식이 달라서 유틸 fetch 함수를 2개로 분리했습니다. 

- 서버에서 동작하는 api면 apiServer, 클라이언트에서 동작하는 api면 apiClient 사용하시면 될 것 같습니다.

- 현재 미들웨어 설정했는데 백엔드 인증 확인 api가 개발되면 추가 작업을 통해 페이지 진입 시 인증 처리는 이곳에서 하면 될 것 같습니다.

- refreshToken으로 재 인증 시 발급 실패하면 로그인 페이지로 리다이렉트 시켰습니다. 그리고 리다이렉트 관련해서 이슈가 생겨 재 인증 호출하는 api에서 try catch문 제거하고 사용하시면 되겠습니다.


## 📢 질문사항
