### PR TITLE
Feat: 면접 전 페이지에서 질문 및 면접 생성 api 통신

### DIFF
--- a/src/components/autocompleteSearch/components/autocompleteInput/type.ts
+++ b/src/components/autocompleteSearch/components/autocompleteInput/type.ts
@@ -1,7 +1,7 @@
-import { AutocompleteDataType } from '../../type';
+import { AutocompleteCreatedDataType, AutocompleteDataType } from '../../type';
 
 export interface AutocompleteInputProps {
   totalDatas: AutocompleteDataType[];
-  selectedList?: AutocompleteDataType[];
+  selectedList?: AutocompleteCreatedDataType[];
   placeholder?: string;
 }

--- a/src/components/autocompleteSearch/contexts/index.tsx
+++ b/src/components/autocompleteSearch/contexts/index.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import useClickAway from '@/hooks/useClickAway';
 
-import { AutocompleteDataType } from '../type';
+import { AutocompleteCreatedDataType, AutocompleteDataType } from '../type';
 import { AutocompleteContextProps, AutocompleteProviderProps } from './type';
 
 const AutocompleteContext = createContext<AutocompleteContextProps>({
@@ -49,7 +49,7 @@ const AutocompleteProvider = ({
   const autoItemRef = useRef(null);
 
   const value = useMemo(() => {
-    const handleItemClick = (item: AutocompleteDataType) => {
+    const handleItemClick = (item: AutocompleteCreatedDataType) => {
       setInputValue('');
       setIsListVisible(false);
       onSelectItem(item);

--- a/src/components/autocompleteSearch/contexts/type.ts
+++ b/src/components/autocompleteSearch/contexts/type.ts
@@ -1,6 +1,6 @@
 import { RefObject } from 'react';
 
-import { AutocompleteDataType } from '../type';
+import { AutocompleteCreatedDataType, AutocompleteDataType } from '../type';
 
 export interface AutocompleteContextProps {
   autocompleteRef: RefObject<HTMLDivElement> | null;
@@ -15,9 +15,9 @@ export interface AutocompleteContextProps {
   setAutocompleteList: (datas: AutocompleteDataType[]) => void;
   keyboardIndex: number;
   setKeyboardIndex: (index: number) => void;
-  handleItemClick: (value: AutocompleteDataType) => void;
+  handleItemClick: (value: AutocompleteCreatedDataType) => void;
 }
 
 export interface AutocompleteProviderProps extends React.PropsWithChildren {
-  onSelectItem: (value: AutocompleteDataType) => void;
+  onSelectItem: (value: AutocompleteCreatedDataType) => void;
 }

--- a/src/components/autocompleteSearch/type.ts
+++ b/src/components/autocompleteSearch/type.ts
@@ -1,12 +1,16 @@
 export interface AutocompleteDataType {
-  id: number | 'new';
+  id: number;
   name: string;
 }
 
+export interface AutocompleteCreatedDataType {
+  id: number | 'new';
+  name: string;
+}
 export interface AutocompleteSearchProps {
   totalDatas: AutocompleteDataType[];
-  onSelectItem: (value: AutocompleteDataType) => void;
+  onSelectItem: (value: AutocompleteCreatedDataType) => void;
   placeholder?: string;
-  selectedList?: AutocompleteDataType[];
+  selectedList?: AutocompleteCreatedDataType[];
   canCreate?: boolean;
 }

--- a/src/container/presetting/components/buttonSection/index.tsx
+++ b/src/container/presetting/components/buttonSection/index.tsx
@@ -28,14 +28,9 @@ const PreSettingButtonSection = () => {
       return;
     }
 
-    let questionId;
+    const isNew = firstQuestion?.id === 'new';
 
-    if (firstQuestion?.id === 'new') {
-      questionId = await createFirstQuestion();
-    } else {
-      questionId = firstQuestion?.id;
-    }
-
+    const questionId = isNew ? await createFirstQuestion() : firstQuestion?.id;
     const interviewId = await createNewInterview(questionId);
 
     const nextUrl =

--- a/src/container/presetting/components/buttonSection/index.tsx
+++ b/src/container/presetting/components/buttonSection/index.tsx
@@ -5,11 +5,13 @@ import { ButtonType } from '@/components/button/types';
 
 import usePresettingDataStore from '../../stores/usePresettingDataStore';
 import useStepStore from '../../stores/useStepStore';
+import usePresetting from '../../usePresetting';
 
 const PreSettingButtonSection = () => {
   const { totalStep, currentStep, increaseStep, decreaseStep, isNextButtonOn } =
     useStepStore();
-  const { interviewType } = usePresettingDataStore();
+  const { firstQuestion, interviewType } = usePresettingDataStore();
+  const { createFirstQuestion, createNewInterview } = usePresetting();
   const router = useRouter();
 
   const handlePrevButton = () => {
@@ -20,14 +22,28 @@ const PreSettingButtonSection = () => {
     }
   };
 
-  const handleNextButton = () => {
+  const handleNextButton = async () => {
     if (currentStep < totalStep) {
       increaseStep();
-    } else {
-      router.push(
-        interviewType === 'camera' ? '/interview/video' : 'interview/chatting',
-      );
+      return;
     }
+
+    let questionId;
+
+    if (firstQuestion?.id === 'new') {
+      questionId = await createFirstQuestion();
+    } else {
+      questionId = firstQuestion?.id;
+    }
+
+    const interviewId = await createNewInterview(questionId);
+
+    const nextUrl =
+      interviewType === 'RECORD'
+        ? `/interview/video/${interviewId}`
+        : `interview/chat/${interviewId}`;
+
+    router.push(nextUrl);
   };
 
   return (

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/index.tsx
@@ -29,7 +29,7 @@ const InterviewTypeSection = ({ setNextItemOn }: InterviewTypeSectionProps) => {
       <div className="flex gap-[2rem]">
         <Button
           styleType={
-            interviewType === 'camera' ? ButtonType.Type1 : ButtonType.Type2
+            interviewType === 'RECORD' ? ButtonType.Type1 : ButtonType.Type2
           }
           onClick={handleCameraButton}
           className="h-[4rem] w-[9.5rem] px-[0rem]"
@@ -38,7 +38,7 @@ const InterviewTypeSection = ({ setNextItemOn }: InterviewTypeSectionProps) => {
         </Button>
         <Button
           styleType={
-            interviewType === 'chatting' ? ButtonType.Type1 : ButtonType.Type2
+            interviewType === 'TEXT' ? ButtonType.Type1 : ButtonType.Type2
           }
           onClick={handleChatButton}
           className="h-[4rem] w-[9.5rem] px-[0rem]"

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
@@ -12,7 +12,7 @@ const TimerSection = () => {
     answerTime.minute === minuteData[minuteData.length - 1],
   );
 
-  if (interviewType === 'chatting') {
+  if (interviewType === 'TEXT') {
     return;
   }
 

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/index.tsx
@@ -17,7 +17,7 @@ const InterviewSettingScene = () => {
     const { minute, second } = answerTime;
     if (
       questionCount &&
-      (interviewType === 'chatting' || !(minute === 0 && second === 0))
+      (interviewType === 'TEXT' || !(minute === 0 && second === 0))
     ) {
       setNextButtonOn();
       return;

--- a/src/container/presetting/components/stepSection/index.tsx
+++ b/src/container/presetting/components/stepSection/index.tsx
@@ -15,11 +15,11 @@ const StepSection = () => {
   const { interviewType } = usePresettingDataStore();
 
   useEffect(() => {
-    if (interviewType === 'camera' || interviewType === undefined) {
-      setCameraStep();
+    if (interviewType === 'TEXT') {
+      setChattingStep();
       return;
     }
-    setChattingStep();
+    setCameraStep();
   }, [interviewType, setCameraStep, setChattingStep]);
 
   return (

--- a/src/container/presetting/stores/type.ts
+++ b/src/container/presetting/stores/type.ts
@@ -1,4 +1,7 @@
-import { AutocompleteDataType } from '../../../components/autocompleteSearch/type';
+import {
+  AutocompleteCreatedDataType,
+  AutocompleteDataType,
+} from '../../../components/autocompleteSearch/type';
 
 export interface StepState {
   totalStep: number;
@@ -14,13 +17,13 @@ export interface StepState {
 
 export interface PresettingDataState {
   firstQuestionTags: AutocompleteDataType[];
-  firstQuestion?: AutocompleteDataType;
+  firstQuestion?: AutocompleteCreatedDataType;
   questionCount: number;
-  interviewType?: 'camera' | 'chatting';
+  interviewType?: 'RECORD' | 'TEXT';
   answerTime: { minute: number; second: number };
   addFirstQuestionTag: (tag: AutocompleteDataType) => void;
   removeFirstQuestionTag: (tag: AutocompleteDataType) => void;
-  setFirstQuestion: (question: AutocompleteDataType | undefined) => void;
+  setFirstQuestion: (question: AutocompleteCreatedDataType | undefined) => void;
   setQuestionCount: (count: number) => void;
   setInterviewTypeCamera: () => void;
   setInterviewTypeChatting: () => void;

--- a/src/container/presetting/stores/usePresettingDataStore.ts
+++ b/src/container/presetting/stores/usePresettingDataStore.ts
@@ -36,12 +36,12 @@ const usePresettingDataStore = create<PresettingDataState>((set) => ({
   },
   setInterviewTypeCamera: () => {
     set(() => ({
-      interviewType: 'camera',
+      interviewType: 'RECORD',
     }));
   },
   setInterviewTypeChatting: () => {
     set(() => ({
-      interviewType: 'chatting',
+      interviewType: 'TEXT',
     }));
   },
   setTimeMinute: (minute) => {

--- a/src/container/presetting/usePresetting.ts
+++ b/src/container/presetting/usePresetting.ts
@@ -1,0 +1,65 @@
+import { notify } from '@/components/toast';
+import {
+  createInterviewByChat,
+  createInterviewByVideo,
+  createQuestion,
+} from '@/services/presetting';
+
+import usePresettingDataStore from './stores/usePresettingDataStore';
+
+const usePresetting = () => {
+  const {
+    firstQuestion,
+    firstQuestionTags,
+    setFirstQuestion,
+    interviewType,
+    questionCount,
+    answerTime,
+  } = usePresettingDataStore();
+
+  const createFirstQuestion = async () => {
+    if (!firstQuestion) {
+      notify('warning', '첫 질문을 올바르게 선택해주세요');
+      return;
+    }
+
+    return createQuestion(
+      firstQuestion.name,
+      firstQuestionTags.map(({ id }) => id),
+    ).then(({ data }) => {
+      setFirstQuestion({
+        id: data.id,
+        name: data.content,
+      });
+      return data.id;
+    });
+  };
+
+  const createNewInterview = async (firstQuestionId: number) => {
+    if (!interviewType || !questionCount) {
+      notify('warning', '설정 값은 필수입니다');
+      return;
+    }
+
+    if (interviewType === 'TEXT') {
+      return createInterviewByChat({
+        questionCount,
+        firstQuestionId,
+      }).then(({ data }) => {
+        return data;
+      });
+    }
+
+    return createInterviewByVideo({
+      questionCount,
+      answerTime,
+      firstQuestionId,
+    }).then(({ data }) => {
+      return data;
+    });
+  };
+
+  return { createFirstQuestion, createNewInterview };
+};
+
+export default usePresetting;


### PR DESCRIPTION
## ✨ Jira 티켓 링크
<!-- 주소 뒤에 티켓번호를 적어주세요 -->
https://devcourse-i6.atlassian.net/browse/htv-230

## 📝 핵심 구현 사항
<!-- 핵심 기능에 대한 설명 -->
- 설정 값을 모두 입력 후, 면접 시작을 눌렀을 때 api 통신을 하도록 구현했습니다
- 질문을 새로 생성한다면 질문 생성 api를 먼저 호출합니다
- 질문 id를 비롯한 여러 설정 값과 함께 인터뷰 api를 호출합니다
- 최종적으로 리턴된 인터뷰id와 함께 인터뷰 연습 페이지로 넘어갑니다

## ✅ 그 외 구현 사항
<!-- 핵심 외 구현 설명 -->
- 네이밍 변경

## 💬 PR 포인트
<!-- PR에서 중점적으로 봐야할 부분 (ex.PR 좀 봐주세요~) -->
이 두 pr만 봐주시면 될 것 같아요!!
- [Feat: presetting api 로직 수정 및 질문, 인터뷰 생성 api 등록](https://github.com/DevCourse-I6/Team-I6-Honterview-FE/commit/c1efa414a6296137c23a36aa9966f9d4a79dcc96)
- [Feat: 면접 생성 api 통신](https://github.com/DevCourse-I6/Team-I6-Honterview-FE/commit/e48f1d74d4e11972e6c0b752f3c56ea99124a449)

## 📢 질문사항
<!-- 질문 & 애로사항 공유 (ex. 어떻게 생각하시나요?) -->
- promise 로직이 잘 짜여졌는지 궁금합니다