### PR TITLE
Fix: 면접 전 레이아웃 버그 수정

### DIFF
--- a/src/components/Header/components/hamburgerMenu/components/mobileNavigation/index.tsx
+++ b/src/components/Header/components/hamburgerMenu/components/mobileNavigation/index.tsx
@@ -17,7 +17,7 @@ const MobileNavigation = () => {
 
           return (
             <li
-              className={`${enabledStyle} cursor-pointer px-10 py-4 hover:bg-background-20`}
+              className={`${enabledStyle} w-full cursor-pointer px-10 py-4 text-center hover:bg-background-20`}
               key={v4uuid()}
             >
               <Link

--- a/src/components/autocompleteSearch/components/autocompleteBox/index.tsx
+++ b/src/components/autocompleteSearch/components/autocompleteBox/index.tsx
@@ -25,14 +25,15 @@ const AutocompleteBox = () => {
       >
         {autocompleteList.map((value, index) => {
           const { prevWord, keyword, postWord } = handleKeywordtHighlight(
-            value.name,
+            value.name.trim(),
           );
 
           return (
             <button
               ref={index === keyboardIndex ? autoItemRef : null}
               type="button"
-              className={`flex h-[3rem] w-full items-center pl-[0.5rem] hover:bg-slate-100 focus:outline-none ${keyboardIndex === index && 'bg-slate-100'}`}
+              className={`flex h-[3rem] items-center pl-[0.5rem] hover:bg-slate-100 focus:outline-none ${keyboardIndex === index && 'bg-slate-100'}`}
+              style={{ width: autoBoxRef?.current?.scrollWidth }}
               key={uuid()}
               onClick={() => handleItemClick(value)}
             >

--- a/src/components/autocompleteSearch/components/autocompleteBox/index.tsx
+++ b/src/components/autocompleteSearch/components/autocompleteBox/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
 import useAutocompleteBox from './useAutocompleteBox';
@@ -7,11 +8,22 @@ const AutocompleteBox = () => {
     autoBoxRef,
     autoItemRef,
     isListVisible,
+    inputValue,
     autocompleteList,
     keyboardIndex,
     handleKeywordtHighlight,
     handleItemClick,
   } = useAutocompleteBox();
+
+  const [autoItemWidth, setAutoItemWidth] = useState<number | undefined>(0);
+
+  useEffect(() => {
+    setAutoItemWidth(0);
+  }, [inputValue]);
+
+  useEffect(() => {
+    setAutoItemWidth(autoBoxRef?.current?.scrollWidth);
+  }, [setAutoItemWidth, autoBoxRef, isListVisible, autoItemWidth]);
 
   if (!isListVisible) {
     return;
@@ -32,8 +44,8 @@ const AutocompleteBox = () => {
             <button
               ref={index === keyboardIndex ? autoItemRef : null}
               type="button"
-              className={`flex h-[3rem] items-center pl-[0.5rem] hover:bg-slate-100 focus:outline-none ${keyboardIndex === index && 'bg-slate-100'}`}
-              style={{ width: autoBoxRef?.current?.scrollWidth }}
+              className={`flex h-[3rem] min-w-full items-center pl-[0.5rem] hover:bg-slate-100 focus:outline-none ${keyboardIndex === index && 'bg-slate-100'}`}
+              style={{ width: autoItemWidth }}
               key={uuid()}
               onClick={() => handleItemClick(value)}
             >

--- a/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
+++ b/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
@@ -12,14 +12,12 @@ const useAutocompleteBox = () => {
   } = useAutocomplete();
 
   const handleKeywordtHighlight = (name: string) => {
-    const value =
-      name.length > 30 ? `${name.trim().slice(0, 30)}...` : name.trim();
     const inputValueTrim = inputValue.trim();
-    const nameArray = Array.from(value);
-    const index = value.toLowerCase().indexOf(inputValueTrim.toLowerCase());
+    const nameArray = Array.from(name);
+    const index = name.toLowerCase().indexOf(inputValueTrim.toLowerCase());
 
     if (index === -1) {
-      return { prevWord: value, keyword: null, postWord: null };
+      return { prevWord: name, keyword: null, postWord: null };
     }
 
     const prevWord = nameArray.slice(0, index).join('');

--- a/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
+++ b/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
@@ -14,16 +14,19 @@ const useAutocompleteBox = () => {
   const handleKeywordtHighlight = (name: string) => {
     const value =
       name.length > 30 ? `${name.trim().slice(0, 30)}...` : name.trim();
+    const inputValueTrim = inputValue.trim();
     const nameArray = Array.from(value);
-    const index = value.toLowerCase().indexOf(inputValue.toLowerCase());
+    const index = value.toLowerCase().indexOf(inputValueTrim.toLowerCase());
 
     if (index === -1) {
       return { prevWord: value, keyword: null, postWord: null };
     }
 
     const prevWord = nameArray.slice(0, index).join('');
-    const keyword = nameArray.slice(index, index + inputValue.length).join('');
-    const postWord = nameArray.slice(index + inputValue.length).join('');
+    const keyword = nameArray
+      .slice(index, index + inputValueTrim.length)
+      .join('');
+    const postWord = nameArray.slice(index + inputValueTrim.length).join('');
 
     return { prevWord, keyword, postWord };
   };

--- a/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
+++ b/src/components/autocompleteSearch/components/autocompleteBox/useAutocompleteBox.ts
@@ -35,6 +35,7 @@ const useAutocompleteBox = () => {
     autocompleteList,
     isListVisible,
     keyboardIndex,
+    inputValue,
     handleKeywordtHighlight,
     handleItemClick,
   };

--- a/src/components/autocompleteSearch/components/autocompleteCreateItem/index.tsx
+++ b/src/components/autocompleteSearch/components/autocompleteCreateItem/index.tsx
@@ -6,7 +6,8 @@ import { QUESTION_MIN_LENGTH } from '../constants';
 const AutocompleteCreateItem = () => {
   const { inputValue, handleItemClick, isCreateVisible } = useAutocomplete();
 
-  if (!inputValue || !isCreateVisible) {
+  const inputValueTrim = inputValue.trim();
+  if (!inputValueTrim || !isCreateVisible) {
     return;
   }
 
@@ -15,21 +16,21 @@ const AutocompleteCreateItem = () => {
       type="button"
       className="z-20 flex h-fit min-h-[3rem] w-full items-center border bg-white py-[0.5rem] pl-[0.5rem] hover:bg-slate-100 focus:outline-none"
       onClick={() => {
-        if (inputValue.length < QUESTION_MIN_LENGTH) {
+        if (inputValueTrim.length < QUESTION_MIN_LENGTH) {
           notify(
             'warning',
-            `질문은 ${QUESTION_MIN_LENGTH}자 이상이어야 합니다`,
+            `질문은 앞 뒤 공백 제외 ${QUESTION_MIN_LENGTH}자 이상이어야 합니다`,
           );
           return;
         }
         handleItemClick({
           id: 'new',
-          name: inputValue,
+          name: inputValueTrim,
         });
       }}
     >
       <p className="max-w-[26rem] overflow-hidden overflow-ellipsis whitespace-nowrap font-semibold text-primaries-primary">
-        {inputValue}
+        {inputValueTrim}
       </p>
       (으)로 질문 생성하기
     </button>

--- a/src/components/autocompleteSearch/components/autocompleteCreateItem/index.tsx
+++ b/src/components/autocompleteSearch/components/autocompleteCreateItem/index.tsx
@@ -28,7 +28,7 @@ const AutocompleteCreateItem = () => {
         });
       }}
     >
-      <p className="auto-text flex w-fit max-w-[22rem] items-center font-semibold text-primaries-primary">
+      <p className="max-w-[26rem] overflow-hidden overflow-ellipsis whitespace-nowrap font-semibold text-primaries-primary">
         {inputValue}
       </p>
       (으)로 질문 생성하기

--- a/src/components/autocompleteSearch/components/autocompleteInput/index.tsx
+++ b/src/components/autocompleteSearch/components/autocompleteInput/index.tsx
@@ -29,23 +29,21 @@ const AutocompleteInput = ({
   };
 
   return (
-    <div className="flex items-center">
-      <Input
-        className="flex h-[3.5rem] w-full gap-[1rem] pl-[0.5rem] outline-none"
-        onKeyDown={onKeyDown}
-      >
-        <div className="autoInput flex w-full gap-[0.5rem] overflow-x-scroll">
-          <Input.Text
-            className="h-[2rem] text-small"
-            onChange={handleChangeInput}
-            value={inputValue}
-            onClick={handleInputClick}
-            placeholder={placeholder ?? '검색어를 입력하세요'}
-          />
-        </div>
-        {!isListVisible && <SearchIcon />}
-      </Input>
-    </div>
+    <Input
+      className="flex h-[3.5rem] w-full gap-[1rem] pl-[0.5rem] outline-none"
+      onKeyDown={onKeyDown}
+    >
+      <div className="autoInput flex w-full gap-[0.5rem] overflow-x-scroll">
+        <Input.Text
+          className="h-[2rem] text-small"
+          onChange={handleChangeInput}
+          value={inputValue}
+          onClick={handleInputClick}
+          placeholder={placeholder ?? '검색어를 입력하세요'}
+        />
+      </div>
+      {!isListVisible && <SearchIcon />}
+    </Input>
   );
 };
 

--- a/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
+++ b/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
@@ -32,7 +32,11 @@ const useAutocompleteInput = ({
 
   const handleInputClick = () => {
     if (!inputValue) {
-      setAutocompleteList(totalDatas);
+      setAutocompleteList(
+        totalDatas.filter(
+          (data) => !selectedList?.some(({ id }) => data.id === id),
+        ),
+      );
     }
     if (autocompleteList.length > 0 || (!inputValue && totalDatas.length)) {
       setIsListVisible(true);
@@ -55,10 +59,7 @@ const useAutocompleteInput = ({
     const newList = totalDatas.filter(
       (data) =>
         data.name.toLocaleLowerCase().includes(lowerValue) &&
-        (!selectedList?.length ||
-          !selectedList?.filter(({ id }) => {
-            return data.id === id;
-          }).length),
+        !selectedList?.some(({ id }) => data.id === id),
     );
     setAutocompleteList(newList);
     newList.length > 0 ? setIsListVisible(true) : setIsListVisible(false);

--- a/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
+++ b/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
@@ -34,7 +34,7 @@ const useAutocompleteInput = ({
     if (!inputValue) {
       setAutocompleteList(totalDatas);
     }
-    if (autocompleteList.length > 0 || !inputValue) {
+    if (autocompleteList.length > 0 || (!inputValue && totalDatas.length)) {
       setIsListVisible(true);
     }
     setIsCreateVisible(true);

--- a/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
+++ b/src/components/autocompleteSearch/components/autocompleteInput/useAutocompleteInput.ts
@@ -50,7 +50,7 @@ const useAutocompleteInput = ({
       return;
     }
 
-    const lowerValue = value.toLowerCase();
+    const lowerValue = value.trim().toLowerCase();
 
     const newList = totalDatas.filter(
       (data) =>

--- a/src/components/autocompleteSearch/style/style.css
+++ b/src/components/autocompleteSearch/style/style.css
@@ -9,11 +9,3 @@
   -ms-overflow-style: none; /* IE and 엣지 */
   scrollbar-width: none; /* 파이어폭스 */
 }
-
-.auto-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-}

--- a/src/container/mypage/components/nickNameSection/components/NicknameEditSection/nicknameEditSection.tsx
+++ b/src/container/mypage/components/nickNameSection/components/NicknameEditSection/nicknameEditSection.tsx
@@ -61,7 +61,6 @@ const NicknameEditSection = ({
             <Input.Text
               value={nickname}
               onChange={onChange}
-              className="w-full"
             />
             <button
               type="button"

--- a/src/container/mypage/components/nickNameSection/components/NicknameEditSection/nicknameEditSection.tsx
+++ b/src/container/mypage/components/nickNameSection/components/NicknameEditSection/nicknameEditSection.tsx
@@ -49,19 +49,19 @@ const NicknameEditSection = ({
       <h2 className="flex select-none text-[2rem] font-semibold">
         닉네임 변경
       </h2>
-      <div className="flex max-w-full flex-col gap-[0.5rem]">
+      <div className="flex w-full flex-col gap-[0.5rem]">
         <div className="w-full text-[1rem] text-text-40">
           한글(자음+모음), 영문, 숫자 입력 가능 (2~20자)
         </div>
         <form
-          className="flex justify-center gap-[0.7rem]"
+          className="flex w-full justify-center gap-[0.7rem]"
           onSubmit={onSubmit}
         >
           <Input className="h-[3rem] w-full border">
             <Input.Text
               value={nickname}
               onChange={onChange}
-              className="w-fit"
+              className="w-full"
             />
             <button
               type="button"

--- a/src/container/presetting/components/buttonSection/index.tsx
+++ b/src/container/presetting/components/buttonSection/index.tsx
@@ -49,7 +49,7 @@ const PreSettingButtonSection = ({
   };
 
   return (
-    <div className="flex flex-1 items-end gap-[1rem] tablet:bottom-[3rem]">
+    <div className="flex items-end gap-[1rem] tablet:bottom-[3rem]">
       <Button
         styleType={ButtonType.Type3}
         className="h-[4rem] w-[9rem] px-[0rem]"

--- a/src/container/presetting/components/sceneSection/components/firstQuestionScene/components/questionSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/firstQuestionScene/components/questionSection/index.tsx
@@ -34,7 +34,7 @@ const QuestionSection = () => {
   }, [firstQuestionTags, firstQuestionTags.length]);
 
   return (
-    <div className="flex max-w-[40rem] flex-col gap-[1rem]">
+    <div className="flex w-full flex-col gap-[1rem]">
       <h2 className="text-large font-semibold">질문 선택</h2>
       <div className="h-[4rem] w-full">
         {isLoading ? (
@@ -52,7 +52,7 @@ const QuestionSection = () => {
         )}
       </div>
       {firstQuestion && (
-        <Tag className="auto-tag relative w-fit max-w-[35rem] overflow-y-scroll border border-primaries-primary bg-white py-[0.5rem] text-primaries-primary hover:bg-white active:bg-white tablet:max-h-[11rem] tablet:max-w-full">
+        <Tag className="auto-tag w-fit overflow-y-scroll border border-primaries-primary bg-white py-[0.5rem] text-primaries-primary hover:bg-white active:bg-white tablet:max-h-[11rem] tablet:max-w-full">
           <span className="max-h-[8rem] tablet:max-h-[11rem]">
             {firstQuestion.name}
           </span>

--- a/src/container/presetting/components/sceneSection/components/firstQuestionScene/components/tagSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/firstQuestionScene/components/tagSection/index.tsx
@@ -33,7 +33,7 @@ const TagSection = () => {
   }, []);
 
   return (
-    <div className="flex max-w-[40rem] flex-col gap-[1rem]">
+    <div className="flex w-full flex-col gap-[1rem]">
       <div className="flex gap-[0.5rem]">
         <h2 className="text-large font-semibold">카테고리 선택</h2>
         <p className="flex items-end text-extraSmall text-text-60">최대 3개</p>

--- a/src/container/presetting/components/sceneSection/components/firstQuestionScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/firstQuestionScene/index.tsx
@@ -24,15 +24,15 @@ const FirstQuestionScene = () => {
   ]);
 
   return (
-    <div className="flex h-full w-full flex-col items-center gap-[4.5rem]">
+    <div className="flex h-full w-full flex-col items-center gap-[4.5rem] tablet:w-[40rem]">
       <p className="flex justify-center pt-[3rem] text-[1.4rem] text-text-80 underline decoration-primaries-primary underline-offset-[1rem] tablet:text-[1.6rem]">
         <b className="text-black">선택한 질문</b>과 이에 대한
         <b className="whitespace-pre text-black"> 꼬리 질문</b>들로 면접이
         진행됩니다
       </p>
-      <div className="flex w-full max-w-[35.9rem] flex-col justify-center gap-[3rem] tablet:gap-[5rem]">
+      <div className="flex w-full flex-col items-center justify-center gap-[3rem] tablet:gap-[5rem]">
         <TagSection />
-        <div className="h-[14rem]">
+        <div className="h-[14rem] w-full">
           {firstQuestionTags.length > 0 && <QuestionSection />}
         </div>
       </div>

--- a/src/container/presetting/components/sceneSection/components/firstQuestionScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/firstQuestionScene/index.tsx
@@ -24,13 +24,8 @@ const FirstQuestionScene = () => {
   ]);
 
   return (
-    <div className="flex h-full w-full flex-col items-center gap-[4.5rem] tablet:w-[40rem]">
-      <p className="flex justify-center pt-[3rem] text-[1.4rem] text-text-80 underline decoration-primaries-primary underline-offset-[1rem] tablet:text-[1.6rem]">
-        <b className="text-black">선택한 질문</b>과 이에 대한
-        <b className="whitespace-pre text-black"> 꼬리 질문</b>들로 면접이
-        진행됩니다
-      </p>
-      <div className="flex w-full flex-col items-center justify-center gap-[3rem] tablet:gap-[5rem]">
+    <div className="flex h-full w-[40rem] flex-col items-center justify-center gap-[4.5rem]">
+      <div className="flex w-full flex-col items-center justify-center gap-[5rem] tablet:gap-[5rem]">
         <TagSection />
         <div className="h-[14rem] w-full">
           {firstQuestionTags.length > 0 && <QuestionSection />}

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/index.tsx
@@ -4,7 +4,10 @@ import useStepStore from '@/container/presetting/stores/useStepStore';
 
 import { InterviewTypeSectionProps } from './type';
 
-const InterviewTypeSection = ({ setNextItemOn }: InterviewTypeSectionProps) => {
+const InterviewTypeSection = ({
+  setNextItemOn,
+  isVisible,
+}: InterviewTypeSectionProps) => {
   const { setInterviewTypeCamera, setInterviewTypeChatting, interviewType } =
     usePresettingDataStore();
   const { setNextButtonOn } = useStepStore();
@@ -21,7 +24,7 @@ const InterviewTypeSection = ({ setNextItemOn }: InterviewTypeSectionProps) => {
   };
 
   return (
-    <div>
+    <div className={`${!isVisible && 'invisible'}`}>
       <h1 className="text-large font-semibold">면접 모드</h1>
       <p className="mb-[1rem] text-extraSmall text-text-60">
         연습 진행 방식을 선택해주세요

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/type.ts
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/interviewTypeSection/type.ts
@@ -1,3 +1,4 @@
 export interface InterviewTypeSectionProps {
   setNextItemOn: (value: boolean) => void;
+  isVisible: boolean;
 }

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/index.tsx
@@ -4,8 +4,9 @@ import usePresettingDataStore from '@/container/presetting/stores/usePresettingD
 
 import TimePicker from './components/timePicker';
 import { minuteData, secondData } from './constants';
+import { TimerSectionProps } from './type';
 
-const TimerSection = () => {
+const TimerSection = ({ isVisible }: TimerSectionProps) => {
   const { setTimeMinute, setTimeSecond, answerTime } = usePresettingDataStore();
   const [isSecondDisabled, setIsSecondDisabled] = useState(
     answerTime.minute === minuteData[minuteData.length - 1],
@@ -22,7 +23,7 @@ const TimerSection = () => {
   };
 
   return (
-    <div>
+    <div className={`${!isVisible && 'invisible'}`}>
       <h1 className="text-large font-semibold">질문당 답변 시간</h1>
       <p className="mb-[1rem] w-[30rem] text-extraSmall text-text-60">
         한 질문당 답변 제한 시간을 선택해주세요 (최대 10분)

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/type.ts
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/components/timerSection/type.ts
@@ -1,0 +1,3 @@
+export interface TimerSectionProps {
+  isVisible: boolean;
+}

--- a/src/container/presetting/components/sceneSection/components/interviewSettingScene/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/interviewSettingScene/index.tsx
@@ -32,16 +32,13 @@ const InterviewSettingScene = () => {
   ]);
 
   return (
-    <div className="relative flex h-full w-[19rem] flex-col justify-center gap-[4rem]">
+    <div className="flex h-full w-[19rem] flex-col justify-center gap-[4rem]">
       <CountSection setNextItemOn={() => setIsTypeVisible(true)} />
-      {isTypeVisible ? (
-        <InterviewTypeSection
-          setNextItemOn={(value) => setIsTimeVisible(value)}
-        />
-      ) : (
-        <div className="h-[9.5rem]" />
-      )}
-      {isTimeVisible ? <TimerSection /> : <div className="h-[14.7rem]" />}
+      <InterviewTypeSection
+        isVisible={isTypeVisible}
+        setNextItemOn={(value) => setIsTimeVisible(value)}
+      />
+      <TimerSection isVisible={isTimeVisible} />
     </div>
   );
 };

--- a/src/container/presetting/components/sceneSection/components/termsScene/components/termsDescriptionSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/components/termsScene/components/termsDescriptionSection/index.tsx
@@ -15,19 +15,19 @@ const TermsDescriptionSection = () => {
       <p className="mb-[1rem] font-semibold">{TERMS_TITLE}</p>
       <div className="mb-[1rem] flex">
         <div className="w-[25rem] border border-r-0">
-          <div className="flex h-[6.5rem] items-center bg-background-20 p-[1rem] tablet:h-fit">
+          <div className="flex h-[8rem] items-center bg-background-20 p-[1rem] tablet:h-fit">
             {TERMS_GOAL_TITLE}
           </div>
           <div className="h-[5rem] p-[1rem]">{TERMS_GOAL_TEXT}</div>
         </div>
         <div className="w-[33rem] border border-r-0">
-          <div className="flex h-[6.5rem] items-center bg-background-20 p-[1rem] tablet:h-fit">
+          <div className="flex h-[8rem] items-center bg-background-20 p-[1rem] tablet:h-fit">
             {TERMS_TARGET_TITLE}
           </div>
           <div className="p-[1rem]">{TERMS_TARGET_TEXT}</div>
         </div>
         <div className="w-[18rem] border">
-          <div className="bg-background-20 p-[1rem]">
+          <div className="flex h-[8rem] items-center bg-background-20 p-[1rem] tablet:h-fit">
             {TERMS_DURATION_TITLE}
           </div>
           <span className="flex p-[1rem]">{TERMS_DURATION_TEXT}</span>

--- a/src/container/presetting/components/sceneSection/index.tsx
+++ b/src/container/presetting/components/sceneSection/index.tsx
@@ -8,7 +8,7 @@ const PreSettingSceneSection = () => {
   const { currentStep } = useStepStore();
 
   return (
-    <div className="flex h-[calc(100%-11.5rem)] w-full items-center justify-center tablet:h-[calc(100%-18rem)]">
+    <div className="flex w-full flex-1 items-center justify-center">
       {currentStep === 1 && <FirstQuestionScene />}
       {currentStep === 2 && <InterviewSettingScene />}
       {currentStep === 3 && <TermsScene />}

--- a/src/container/presetting/components/stepSection/index.tsx
+++ b/src/container/presetting/components/stepSection/index.tsx
@@ -1,3 +1,5 @@
+import './style.css';
+
 import { useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -22,7 +24,7 @@ const StepSection = () => {
   }, [interviewType, setCameraStep, setChattingStep]);
 
   return (
-    <div className="relative flex w-full justify-center text-[1.4rem] font-semibold tablet:h-[12rem] tablet:items-center tablet:px-[3rem] tablet:text-[1.6rem]">
+    <div className="relative flex w-full justify-center gap-[1rem] text-[1.3rem] font-semibold tablet:h-[12rem] tablet:items-center tablet:px-[3rem] tablet:text-[1.6rem]">
       {Array.from({ length: totalStep }, (_, i) => i + 1).map((step) => (
         <div
           className="flex items-center justify-center"
@@ -33,13 +35,23 @@ const StepSection = () => {
               number={step}
               isPassed={currentStep >= step}
             />
-            <span
-              className={`flex w-[9.5rem] items-center justify-center 
+            <div className="relative flex w-[8rem] items-center justify-center gap-[0.3rem] tablet:w-[9.5rem]">
+              <span
+                className={`flex items-center justify-center 
               ${currentStep === step ? 'text-primaries-primary' : 'text-text-80'}
             `}
-            >
-              {TITLE_LIST[step as StepNumber]}
-            </span>
+              >
+                {TITLE_LIST[step as StepNumber]}
+              </span>
+              {step === 1 && (
+                <span className="tooltip-mark flex h-[1.4rem] w-[1.4rem] select-none items-center justify-center rounded-full border-[0.13rem] border-text-80 text-[1.1rem] text-text-80 tablet:h-[1.5rem] tablet:w-[1.5rem] tablet:text-[1.2rem]">
+                  <div className="tooltip-box invisible absolute left-0 top-[120%] z-10 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-[1.5rem] font-medium text-white opacity-0 shadow-sm transition-opacity duration-300">
+                    첫 질문과 이에 대한 꼬리 질문들로 면접이 진행됩니다
+                  </div>
+                  ?
+                </span>
+              )}
+            </div>
           </div>
           {step !== totalStep && (
             <StepBar

--- a/src/container/presetting/components/stepSection/index.tsx
+++ b/src/container/presetting/components/stepSection/index.tsx
@@ -35,7 +35,7 @@ const StepSection = () => {
               number={step}
               isPassed={currentStep >= step}
             />
-            <div className="relative flex w-[8rem] items-center justify-center gap-[0.3rem] tablet:w-[9.5rem]">
+            <div className="relative flex w-[8rem] items-center justify-center gap-[0.2rem] tablet:w-[9.5rem] tablet:gap-[0.3rem]">
               <span
                 className={`flex items-center justify-center 
               ${currentStep === step ? 'text-primaries-primary' : 'text-text-80'}

--- a/src/container/presetting/components/stepSection/style.css
+++ b/src/container/presetting/components/stepSection/style.css
@@ -1,0 +1,5 @@
+.tooltip-mark:hover .tooltip-box,
+.tooltip-mark:focus .tooltip-box {
+  visibility: visible;
+  opacity: 1;
+}

--- a/src/container/presetting/index.tsx
+++ b/src/container/presetting/index.tsx
@@ -58,7 +58,7 @@ const PreSetting = ({ firstQuestionId }: PreSettingProps) => {
     <div className=" flex h-[70rem] max-h-full w-full flex-col items-center rounded-3xl bg-text-20 bg-opacity-20 p-[2rem] text-[1.6rem] shadow-[0_8px_30px_rgb(0,0,0,0.12)] tablet:h-[70rem] tablet:max-w-[80rem]">
       <StepSection />
       <DividerHorizontal className="mx-[1rem] mt-[1rem] w-full" />
-      <div className="flex h-full flex-col items-center">
+      <div className="flex h-full w-full flex-col items-center">
         <PreSettingSceneSection />
         <PreSettingButtonSection fromQuestionPage={!!firstQuestionId} />
       </div>


### PR DESCRIPTION
## ✨ Jira 티켓 링크
<!-- 주소 뒤에 티켓번호를 적어주세요 -->
https://devcourse-i6.atlassian.net/browse/htv-261

## 📝 핵심 구현 사항
<!-- 핵심 기능에 대한 설명 -->
면접 전 화면의 레이아웃 버그를 수정했습니다
- 레이아웃이 위로 오버플로우 되는 현상
- 첫화면에서 검색어에 따라 검색바가 늘어나는 현상
- 자동완성 생성에서 말줄임표 나올 시 왼쪽 공백이 생기는 현상
- 입력 값의 앞뒤 공백을 제거한 값으로 키워드를 세팅
- 자동완성 검색바의 input값이 없을 때에도 이미 추가된 태그는 나오지 않도록 수정
- 면접전 첫화면의 설명을 툴팁으로 UI 변경

## ✅ 그 외 구현 사항
<!-- 핵심 외 구현 설명 -->
- 마이페이지 닉네임 수정 레이아웃도 수정했습니다
- Header의 햄버거 메뉴들 호버 시 빈공간이 나오는 현상 수정

## 💬 PR 포인트
<!-- PR에서 중점적으로 봐야할 부분 (ex.PR 좀 봐주세요~) -->

## 📢 질문사항
<!-- 질문 & 애로사항 공유 (ex. 어떻게 생각하시나요?) -->
